### PR TITLE
HG-5758: Replace joblib by concurrent futures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,7 @@ setup(name="pipelinewise-target-postgres",
       install_requires=[
           'pipelinewise-singer-python==1.*',
           'psycopg2-binary==2.9.3',
-          'inflection==0.3.1',
-          'joblib==0.16.0'
+          'inflection==0.3.1'
       ],
       extras_require={
           "test": [

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -49,7 +49,7 @@ def _run_parallel_fail_fast(
             future.result()
     except Exception:
         # Do not wait for remaining workers; exit quickly and re-raise
-        executor.shutdown(wait=False)
+        executor.shutdown(wait=False, cancel_futures=True)
         raise
     else:
         executor.shutdown(wait=True)

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -34,7 +34,8 @@ def _run_parallel_fail_fast(
     Run load_stream_batch for each stream in parallel with fail-fast behavior:
     on first exception, do not wait for remaining workers; re-raise immediately.
     """
-    with ThreadPoolExecutor(max_workers=parallelism) as executor:
+    executor = ThreadPoolExecutor(max_workers=parallelism)
+    try:
         futures = {
             executor.submit(
                 load_stream_batch,
@@ -43,14 +44,15 @@ def _run_parallel_fail_fast(
             ): stream
             for stream in streams_to_flush
         }
-        try:
-            for future in as_completed(futures):
-                # Raise immediately on first exception; no blocking on other workers
-                future.result()
-        except Exception:
-            # Do not wait for remaining workers; exit quickly and re-raise
-            executor.shutdown(wait=False)
-            raise
+        for future in as_completed(futures):
+            # Raise immediately on first exception; no blocking on other workers
+            future.result()
+    except Exception:
+        # Do not wait for remaining workers; exit quickly and re-raise
+        executor.shutdown(wait=False)
+        raise
+    else:
+        executor.shutdown(wait=True)
 
 
 class RecordValidationException(Exception):

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -48,8 +48,11 @@ def _run_parallel_fail_fast(
             # Raise immediately on first exception; no blocking on other workers
             future.result()
     except Exception:
-        # Do not wait for remaining workers; exit quickly and re-raise
-        executor.shutdown(wait=False, cancel_futures=True)
+        # Cancel pending futures
+        for f in futures:
+            f.cancel()
+
+        executor.shutdown(wait=False)
         raise
     else:
         executor.shutdown(wait=True)

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -7,11 +7,11 @@ import os
 import sys
 import copy
 import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from decimal import Decimal
 from tempfile import mkstemp
 
-from joblib import Parallel, delayed, parallel_backend
 from jsonschema import Draft7Validator, FormatChecker
 from singer import get_logger
 
@@ -23,6 +23,34 @@ LOGGER = get_logger('target_postgres')
 DEFAULT_BATCH_SIZE_ROWS = 100000
 DEFAULT_PARALLELISM = 0  # 0 The number of threads used to flush tables
 DEFAULT_MAX_PARALLELISM = 16  # Don't use more than this number of threads by default when flushing streams in parallel
+
+
+def _run_parallel_fail_fast(
+    streams_to_flush,
+    load_stream_batch_args,
+    parallelism,
+):
+    """
+    Run load_stream_batch for each stream in parallel with fail-fast behavior:
+    on first exception, do not wait for remaining workers; re-raise immediately.
+    """
+    with ThreadPoolExecutor(max_workers=parallelism) as executor:
+        futures = {
+            executor.submit(
+                load_stream_batch,
+                stream=stream,
+                **load_stream_batch_args(stream),
+            ): stream
+            for stream in streams_to_flush
+        }
+        try:
+            for future in as_completed(futures):
+                # Raise immediately on first exception; no blocking on other workers
+                future.result()
+        except Exception:
+            # Do not wait for remaining workers; exit quickly and re-raise
+            executor.shutdown(wait=False)
+            raise
 
 
 class RecordValidationException(Exception):
@@ -315,17 +343,21 @@ def flush_streams(
         filter_streams=filter_streams
     )
 
-    # Single-host, thread-based parallelism
+    def load_stream_batch_args(stream):
+        return {
+            'records_to_load': streams[stream],
+            'row_count': row_count,
+            'db_sync': stream_to_sync[stream],
+            'delete_rows': config.get('hard_delete'),
+            'temp_dir': config.get('temp_dir'),
+        }
+
     try:
-        with parallel_backend('threading', n_jobs=parallelism):
-            Parallel()(delayed(load_stream_batch)(
-                stream=stream,
-                records_to_load=streams[stream],
-                row_count=row_count,
-                db_sync=stream_to_sync[stream],
-                delete_rows=config.get('hard_delete'),
-                temp_dir=config.get('temp_dir')
-            ) for stream in streams_to_flush)
+        _run_parallel_fail_fast(
+            streams_to_flush,
+            load_stream_batch_args,
+            parallelism,
+        )
     except Exception as exc:
         log_event(
             LOGGER,

--- a/target_postgres/__init__.py
+++ b/target_postgres/__init__.py
@@ -35,6 +35,7 @@ def _run_parallel_fail_fast(
     on first exception, do not wait for remaining workers; re-raise immediately.
     """
     executor = ThreadPoolExecutor(max_workers=parallelism)
+    futures = {}
     try:
         futures = {
             executor.submit(


### PR DESCRIPTION
## Problem

When one stream failed during a parallel flush (e.g. DuplicateColumn: column "sourceplatform" specified more than once), the target sometimes hung instead of exiting

## Cause

Target was using joblib, which collects results in order. If worker 3 failed but workers 1 and 2 were still running or blocked the main thread stucks on job.get() for the first job and never got to the failing one, so it never exits.

## Fix

Replaced joblib with ThreadPoolExecutor and as_completed(), it nows handle results as they finish and re-raise on the first exception, and call executor.shutdown(wait=False) so we don’t wait for remaining workers.